### PR TITLE
This fixes the JS so that pronoun field will always display where the profile configures it to be shown

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.pronouns</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2025-11-13</releaseDate>
-  <version>1.3.0</version>
+  <releaseDate>2025-11-18</releaseDate>
+  <version>1.3.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.38</ver>

--- a/js/pronoun.js
+++ b/js/pronoun.js
@@ -6,9 +6,6 @@
   let pronoun_options = $('.editrow_pronoun_options');
   $('#pronoun_custom_options').prepend(pronoun_options);
   $('#pronoun_custom_field').hide();
-  //if (CRM.vars.pronouns.profile) {
-  //  $('#profile-submit-buttons').append($('.crm-submit-buttons'));
-  //}
   let pronoun_options_input_field = $('.editrow_pronoun_options').find('input[name=pronoun_options]');
   pronoun_options_input_field.on('change', function() {
     let pronoun = $('.editrow_pronoun_options').find('.select2-chosen').text();

--- a/js/pronoun.js
+++ b/js/pronoun.js
@@ -1,14 +1,13 @@
 (function($) {
   let pronoun_custom_field = $('.pronoun_custom_field_text_box').parent().parent();
-  let fieldSet =  $('.pronoun_custom_field_text_box').parent().parent().parent();
-  fieldSet.append('<div id="pronoun_custom_options"></div><div id="pronoun_custom_field"></div><div id="profile-submit-buttons"></div>');
+  pronoun_custom_field.wrap('<div id="pronoun_custom_options"></div><div id="pronoun_custom_field"></div><div id="profile-submit-buttons"></div>');
   $('#pronoun_custom_field').append(pronoun_custom_field);
   let pronoun_options = $('.editrow_pronoun_options');
   $('#pronoun_custom_options').append(pronoun_options);
   $('#pronoun_custom_field').hide();
-  if (CRM.vars.pronouns.profile) {
-    $('#profile-submit-buttons').append($('.crm-submit-buttons'));
-  }
+  //if (CRM.vars.pronouns.profile) {
+  //  $('#profile-submit-buttons').append($('.crm-submit-buttons'));
+  //}
   let pronoun_options_input_field = $('.editrow_pronoun_options').find('input[name=pronoun_options]');
   pronoun_options_input_field.on('change', function() {
     let pronoun = $('.editrow_pronoun_options').find('.select2-chosen').text();

--- a/js/pronoun.js
+++ b/js/pronoun.js
@@ -4,7 +4,7 @@
   $('#pronoun_custom_options').append('<div id="pronoun_custom_field"></div>');
   $('#pronoun_custom_field').append(pronoun_custom_field);
   let pronoun_options = $('.editrow_pronoun_options');
-  $('#pronoun_custom_options').append(pronoun_options);
+  $('#pronoun_custom_options').prepend(pronoun_options);
   $('#pronoun_custom_field').hide();
   //if (CRM.vars.pronouns.profile) {
   //  $('#profile-submit-buttons').append($('.crm-submit-buttons'));

--- a/js/pronoun.js
+++ b/js/pronoun.js
@@ -1,6 +1,7 @@
 (function($) {
   let pronoun_custom_field = $('.pronoun_custom_field_text_box').parent().parent();
-  pronoun_custom_field.wrap('<div id="pronoun_custom_options"></div><div id="pronoun_custom_field"></div><div id="profile-submit-buttons"></div>');
+  pronoun_custom_field.wrap('<div id="pronoun_custom_options"></div>');
+  $('#pronoun_custom_options').append('<div id="pronoun_custom_field"></div>');
   $('#pronoun_custom_field').append(pronoun_custom_field);
   let pronoun_options = $('.editrow_pronoun_options');
   $('#pronoun_custom_options').append(pronoun_options);

--- a/pronouns.php
+++ b/pronouns.php
@@ -32,13 +32,6 @@ function pronouns_civicrm_enable() {
 
 function pronouns_civicrm_buildForm($formName, $form) {
   if ($formName != 'CRM_Contribute_Form_Contribution_Confirm' || $formName == 'CRM_Contribute_Form_Contribution_ThankYou') {
-    if ($formName == 'CRM_Profile_Form_Edit') {
-      $profile = TRUE;
-    }
-    else {
-      $profile = FALSE;
-    }
-    CRM_Core_Resources::singleton()->addVars('pronouns', ['profile' => $profile]);
     $options = [];
     $pronounOptions = civicrm_api3('OptionValue', 'get', ['option_group_id' => 'pronouns', ['return' => ['label', 'value']]]);
     foreach ($pronounOptions['values'] as $option) {


### PR DESCRIPTION
Previously the pronoun field would go to the bottom of the field set the custom field was in, now it stays in the order as the profile decides